### PR TITLE
Mention --skip-env-file switch in the dotenv docs

### DIFF
--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -6,7 +6,9 @@ title: Declare default environment variables in file
 
 Compose supports declaring default environment variables in an environment file
 named `.env` placed in the folder where the `docker-compose` command is executed
-*(current working directory)*.
+*(current working directory)*. 
+
+If you do not wish for Compose to read your `.env` file - use `--skip-env-file` option.
 
 ## Syntax rules
 


### PR DESCRIPTION
### Proposed changes

Mention `--skip-env-file` option in the `.env` documentation. This should be merged (or closed) along with https://github.com/docker/compose/pull/6850

### Related issues (optional)

https://github.com/docker/compose/pull/6850
